### PR TITLE
update: modify StaticListUploadRequest to use array instead of map

### DIFF
--- a/src/lib/staticlists/StaticListUploadRequest.ts
+++ b/src/lib/staticlists/StaticListUploadRequest.ts
@@ -15,7 +15,7 @@ export class StaticListUploadRequest implements IRequest {
   }
 
   getRequestBody(): string {
-    return Array.from(this.listContent).reduce(
+    return this.listContent.reduce(
       (old, [key, value]) => {
         return old.concat(`${key},${value}\n`)
       },

--- a/src/lib/staticlists/StaticListUploadRequest.ts
+++ b/src/lib/staticlists/StaticListUploadRequest.ts
@@ -8,14 +8,14 @@ import {
 } from '../Constants'
 
 export class StaticListUploadRequest implements IRequest {
-  constructor(public name: string, public listContent: Map<string, string>) {}
+  constructor(public name: string, public listContent: Array<[string, string]>) {}
 
   getHttpMethod(): HttpMethod {
     return HttpMethod.PUT
   }
 
   getRequestBody(): string {
-    return Array.from(this.listContent.entries()).reduce(
+    return Array.from(this.listContent).reduce(
       (old, [key, value]) => {
         return old.concat(`${key},${value}\n`)
       },


### PR DESCRIPTION
changed typing for constructor method, modified `getRequestBody` to use `this.listContent` as an array instead of a map.