### PR TITLE
Feature/get url and make response returns consistent

### DIFF
--- a/src/lib/client/IRequestClient.ts
+++ b/src/lib/client/IRequestClient.ts
@@ -4,4 +4,5 @@ import { Response } from './Response'
 
 export interface IRequestClient {
   execute<T>(request: IRequest, headers: IHeaders): Promise<Response<T>>
+  getUrl(req?: IRequest): string
 }

--- a/src/lib/client/RequestClient.ts
+++ b/src/lib/client/RequestClient.ts
@@ -12,7 +12,10 @@ export class RequestClient implements IRequestClient {
     this.baseUrl = base
   }
 
-  execute<T>(clientRequest: IRequest, headers: IHeaders): Promise<Response<T>> {
+  async execute<T>(
+    clientRequest: IRequest,
+    headers: IHeaders,
+  ): Promise<Response<T>> {
     return new Promise((resolve, reject) => {
       let reqHeaders = headers
       const clientHeaders = clientRequest.getRequestHeaders()
@@ -29,11 +32,9 @@ export class RequestClient implements IRequestClient {
         // tslint:disable-next-line:no-magic-numbers
         const hasError = res.statusCode < 200 || res.statusCode >= 300
         if (err || hasError) {
-          reject(err || { statusCode: res.statusCode, error: body })
+          reject(err || new Response(res.statusCode, JSON.parse(body)))
         } else {
-          resolve(
-            new Response(JSON.parse(body), undefined as any, res.statusCode),
-          )
+          resolve(new Response(res.statusCode, JSON.parse(body)))
         }
       }
 

--- a/src/lib/client/RequestClient.ts
+++ b/src/lib/client/RequestClient.ts
@@ -55,4 +55,8 @@ export class RequestClient implements IRequestClient {
       }
     })
   }
+
+  getUrl(req?: IRequest) {
+    return req ? this.baseUrl + req.getUriPath() : this.baseUrl
+  }
 }

--- a/src/lib/client/Response.ts
+++ b/src/lib/client/Response.ts
@@ -1,9 +1,9 @@
 export class Response<T> {
   body: T
-  headers: Map<string, string>
+  headers?: Map<string, string>
   status: number
 
-  constructor(body: T, headers: Map<string, string>, status: number) {
+  constructor(status: number, body: T, headers?: Map<string, string>) {
     this.body = body
     this.headers = headers
     this.status = status


### PR DESCRIPTION
added function to RequestClient that will return the request url-- full or base if no request is passed into the function
error request responses were returning `statusCode`, while successful req responses were returning `status`. made them consistent.