### PR TITLE
fix: needed to put `getUrl` on `UrbanAirshipClient`

### DIFF
--- a/src/lib/client/UrbanAirshipClient.ts
+++ b/src/lib/client/UrbanAirshipClient.ts
@@ -18,8 +18,12 @@ export class UrbanAirshipClient {
     this.requestClient = new RequestClient(BASE_URL)
   }
 
-  execute<T>(clientRequest: IRequest): Promise<Response<T>> {
+  async execute<T>(clientRequest: IRequest): Promise<Response<T>> {
     return this.requestClient.execute(clientRequest, this.getHeaders())
+  }
+
+  getUrl(req?: IRequest): string {
+    return this.requestClient.getUrl(req)
   }
 
   private getHeaders(): IHeaders {


### PR DESCRIPTION
I put it on `RequestClient`, but that's a private member of `UrbanAirshipClient`. So I made it function the same way `execute` does-- `UrbanAirshipClient` calls `this.requestClient.getUrl(req)`.