### PR TITLE
RESO-1180: Add remove user tags and tests for NamedUserTagRequest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,4 @@ module.exports = {
   },
   testMatch: ['**/test/**/*.test.(ts|js)'],
   testPathIgnorePatterns: ['/dist/'],
-  testEnvironment: './test/config/mongoEnvironment.js',
-  setupTestFrameworkScriptFile: './test/config/setupTestFrameworkScript.js',
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-urban-airship-client",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2584,7 +2584,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2605,12 +2606,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2625,17 +2628,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2752,7 +2758,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2764,6 +2771,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2778,6 +2786,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2785,12 +2794,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2809,6 +2820,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2889,7 +2901,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2901,6 +2914,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2986,7 +3000,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3022,6 +3037,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3041,6 +3057,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3084,12 +3101,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-urban-airship-client",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A client library to help with interacting with the Urban Airship API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/nameduser/NamedUserTagRequest.ts
+++ b/src/lib/nameduser/NamedUserTagRequest.ts
@@ -9,12 +9,25 @@ import {
 
 const NAMED_USER_ID_KEY = 'named_user_id'
 
+interface IPayload {
+  audience: Record<typeof NAMED_USER_ID_KEY, string[]>
+  add?: Record<string, string[]>
+  remove?: Record<string, string[]>
+}
+
 export class NamedUserTagRequest implements IRequest {
-  audience: { [NAMED_USER_ID_KEY]: string[] } = { [NAMED_USER_ID_KEY]: [] }
-  add: { [key: string]: string[] } = {}
+  audience: Record<typeof NAMED_USER_ID_KEY, string[]> = {
+    [NAMED_USER_ID_KEY]: [],
+  }
+  add: Record<string, string[]> = {}
+  remove: Record<string, string[]> = {}
 
   addTags(tagGroup: string, tags: string[]) {
     this.addValuesToKey(this.add, tagGroup, ...tags)
+  }
+
+  removeTags(tagGroup: string, tags: string[]) {
+    this.addValuesToKey(this.remove, tagGroup, ...tags)
   }
 
   addNamedUsers(...namedUsers: string[]) {
@@ -26,7 +39,19 @@ export class NamedUserTagRequest implements IRequest {
   }
 
   getRequestBody(): string {
-    return JSON.stringify(this)
+    const payload: IPayload = {
+      audience: this.audience,
+    }
+
+    if (Object.keys(this.add).length) {
+      payload['add'] = this.add
+    }
+
+    if (Object.keys(this.remove).length) {
+      payload['remove'] = this.remove
+    }
+
+    return JSON.stringify(payload)
   }
 
   getRequestHeaders(): IHeaders {

--- a/test/unit/lib/nameduser/NamedUserTagRequest.test.ts
+++ b/test/unit/lib/nameduser/NamedUserTagRequest.test.ts
@@ -1,12 +1,25 @@
+import {
+  ACCEPT_HEADER,
+  CONTENT_TYPE,
+  CONTENT_TYPE_JSON,
+  UA_VERSION_JSON,
+} from '../../../../src/lib/Constants'
+import { HttpMethod } from '../../../../src/lib/client/IRequest'
 import { NamedUserTagRequest } from '../../../../src/lib/nameduser/NamedUserTagRequest'
 
-const mockNamedUsers = ['user1', 'user2', 'user3']
-const mockTagGroup = 'fakeTagGroup'
-const mockTags = ['tag1', 'tag2', 'tag3']
+let namedUserTagRequest: NamedUserTagRequest
+let mockNamedUsers: string[]
+let mockTagGroup: string
+let mockTags: string[]
+
+beforeEach(() => {
+  namedUserTagRequest = new NamedUserTagRequest()
+  mockNamedUsers = ['user1', 'user2', 'user3']
+  mockTagGroup = 'fakeTagGroup'
+  mockTags = ['tag1', 'tag2', 'tag3']
+})
 
 it('adds named users to audience', () => {
-  const namedUserTagRequest = new NamedUserTagRequest()
-
   namedUserTagRequest.addNamedUsers(...mockNamedUsers)
 
   expect(namedUserTagRequest.audience).toEqual({
@@ -15,8 +28,6 @@ it('adds named users to audience', () => {
 })
 
 it('adds add tags', () => {
-  const namedUserTagRequest = new NamedUserTagRequest()
-
   namedUserTagRequest.addTags(mockTagGroup, mockTags)
 
   expect(namedUserTagRequest.add).toEqual({
@@ -25,8 +36,6 @@ it('adds add tags', () => {
 })
 
 it('adds remove tags', () => {
-  const namedUserTagRequest = new NamedUserTagRequest()
-
   namedUserTagRequest.removeTags(mockTagGroup, mockTags)
 
   expect(namedUserTagRequest.remove).toEqual({
@@ -34,10 +43,31 @@ it('adds remove tags', () => {
   })
 })
 
+it('http method should be POST', () => {
+  const receivedHttpMethod = namedUserTagRequest.getHttpMethod()
+
+  expect(receivedHttpMethod).toEqual(HttpMethod.POST)
+})
+
+it('uri path is named user tags', () => {
+  const receivedUriPath = namedUserTagRequest.getUriPath()
+
+  expect(receivedUriPath).toEqual('/api/named_users/tags/')
+})
+
+it('should get correct request headers', () => {
+  const receivedRequestHeaders = namedUserTagRequest.getRequestHeaders()
+
+  const expectedRequestHeaders = {
+    [CONTENT_TYPE]: CONTENT_TYPE_JSON,
+    [ACCEPT_HEADER]: UA_VERSION_JSON,
+  }
+
+  expect(receivedRequestHeaders).toEqual(expectedRequestHeaders)
+})
+
 describe('getRequestBody', () => {
   it('gets request body (+named users, +add tags, -remove tags)', () => {
-    const namedUserTagRequest = new NamedUserTagRequest()
-
     namedUserTagRequest.addNamedUsers(...mockNamedUsers)
     namedUserTagRequest.addTags(mockTagGroup, mockTags)
 
@@ -52,8 +82,6 @@ describe('getRequestBody', () => {
   })
 
   it('gets request body (+named users, -add tags, +remove tags)', () => {
-    const namedUserTagRequest = new NamedUserTagRequest()
-
     namedUserTagRequest.addNamedUsers(...mockNamedUsers)
     namedUserTagRequest.removeTags(mockTagGroup, mockTags)
 
@@ -68,8 +96,6 @@ describe('getRequestBody', () => {
   })
 
   it('gets request body (+named users, +add tags, +remove tags)', () => {
-    const namedUserTagRequest = new NamedUserTagRequest()
-
     namedUserTagRequest.addNamedUsers(...mockNamedUsers)
     namedUserTagRequest.addTags(mockTagGroup, mockTags)
     namedUserTagRequest.removeTags(mockTagGroup, mockTags)

--- a/test/unit/lib/nameduser/NamedUserTagRequest.test.ts
+++ b/test/unit/lib/nameduser/NamedUserTagRequest.test.ts
@@ -1,0 +1,87 @@
+import { NamedUserTagRequest } from '../../../../src/lib/nameduser/NamedUserTagRequest'
+
+const mockNamedUsers = ['user1', 'user2', 'user3']
+const mockTagGroup = 'fakeTagGroup'
+const mockTags = ['tag1', 'tag2', 'tag3']
+
+it('adds named users to audience', () => {
+  const namedUserTagRequest = new NamedUserTagRequest()
+
+  namedUserTagRequest.addNamedUsers(...mockNamedUsers)
+
+  expect(namedUserTagRequest.audience).toEqual({
+    named_user_id: mockNamedUsers,
+  })
+})
+
+it('adds add tags', () => {
+  const namedUserTagRequest = new NamedUserTagRequest()
+
+  namedUserTagRequest.addTags(mockTagGroup, mockTags)
+
+  expect(namedUserTagRequest.add).toEqual({
+    [mockTagGroup]: mockTags,
+  })
+})
+
+it('adds remove tags', () => {
+  const namedUserTagRequest = new NamedUserTagRequest()
+
+  namedUserTagRequest.removeTags(mockTagGroup, mockTags)
+
+  expect(namedUserTagRequest.remove).toEqual({
+    [mockTagGroup]: mockTags,
+  })
+})
+
+describe('getRequestBody', () => {
+  it('gets request body (+named users, +add tags, -remove tags)', () => {
+    const namedUserTagRequest = new NamedUserTagRequest()
+
+    namedUserTagRequest.addNamedUsers(...mockNamedUsers)
+    namedUserTagRequest.addTags(mockTagGroup, mockTags)
+
+    const receivedRequestBody = namedUserTagRequest.getRequestBody()
+
+    const expectedRequestBody = JSON.stringify({
+      audience: { named_user_id: mockNamedUsers },
+      add: { [mockTagGroup]: mockTags },
+    })
+
+    expect(receivedRequestBody).toEqual(expectedRequestBody)
+  })
+
+  it('gets request body (+named users, -add tags, +remove tags)', () => {
+    const namedUserTagRequest = new NamedUserTagRequest()
+
+    namedUserTagRequest.addNamedUsers(...mockNamedUsers)
+    namedUserTagRequest.removeTags(mockTagGroup, mockTags)
+
+    const receivedRequestBody = namedUserTagRequest.getRequestBody()
+
+    const expectedRequestBody = JSON.stringify({
+      audience: { named_user_id: mockNamedUsers },
+      remove: { [mockTagGroup]: mockTags },
+    })
+
+    expect(receivedRequestBody).toEqual(expectedRequestBody)
+  })
+
+  it('gets request body (+named users, +add tags, +remove tags)', () => {
+    const namedUserTagRequest = new NamedUserTagRequest()
+
+    namedUserTagRequest.addNamedUsers(...mockNamedUsers)
+    namedUserTagRequest.addTags(mockTagGroup, mockTags)
+    namedUserTagRequest.removeTags(mockTagGroup, mockTags)
+
+    const receivedRequestBody = namedUserTagRequest.getRequestBody()
+
+    const expectedRequestBody = JSON.stringify({
+      audience: { named_user_id: mockNamedUsers },
+      add: { [mockTagGroup]: mockTags },
+      remove: { [mockTagGroup]: mockTags },
+    })
+
+    expect(receivedRequestBody).toEqual(expectedRequestBody)
+  })
+})


### PR DESCRIPTION
- Adds `remove` tags to payload for named user tag request
- There were currently no tests for this project, however, I went ahead and added tests for the file I touched
- Payload matches to API docs here: https://docs.airship.com/api/ua/index.html#operation-api-named_users-tags-post

Once we're good with these changes, we'll obviously have to publish a new version to NPM and update the version within the backend repo