### PR TITLE
RESO-2736: Improve error handling with non-JSON response bodies

### DIFF
--- a/src/lib/client/RequestClient.ts
+++ b/src/lib/client/RequestClient.ts
@@ -1,4 +1,4 @@
-import * as request from 'request'
+import request from 'request'
 
 import { IHeaders } from './IHeaders'
 import { HttpMethod, IRequest } from './IRequest'
@@ -30,13 +30,12 @@ export class RequestClient implements IRequestClient {
 
       const callback = (err: any, res: request.Response, body: any) => {
         // tslint:disable-next-line:no-magic-numbers
-        const hasError = res.statusCode < 200 || res.statusCode >= 300
+        const hasError = res && (res.statusCode < 200 || res.statusCode >= 300)
+
         if (err || hasError) {
-          reject(err || new Response(res.statusCode, JSON.parse(body)))
+          reject(err || new Response(res.statusCode, tryParseBody(body)))
         } else {
-          resolve(
-            new Response(res.statusCode, body ? JSON.parse(body) : undefined),
-          )
+          resolve(new Response(res.statusCode, tryParseBody(body)))
         }
       }
 
@@ -61,5 +60,13 @@ export class RequestClient implements IRequestClient {
 
   getUrl(req?: IRequest) {
     return req ? this.baseUrl + req.getUriPath() : this.baseUrl
+  }
+}
+
+function tryParseBody(body: any) {
+  try {
+    return body ? JSON.parse(body) : undefined
+  } catch (e) {
+    return undefined
   }
 }

--- a/test/unit/lib/client/RequestClient.test.ts
+++ b/test/unit/lib/client/RequestClient.test.ts
@@ -1,0 +1,91 @@
+import request from 'request'
+
+import { PushRequest } from '../../../../src/lib/pushes/PushRequest'
+import { RequestClient } from '../../../../src/lib/client/RequestClient'
+import { Response } from '../../../../src/lib/client/Response'
+
+let client: RequestClient
+let postSpy: jest.SpyInstance
+
+beforeEach(() => {
+  client = new RequestClient('')
+  postSpy = jest.spyOn(request, 'post')
+})
+
+describe('when receiving success response', () => {
+  it('parses JSON body without error', async () => {
+    const req = new PushRequest()
+
+    const body = { foo: 'bar' }
+    mockResponseOnce(200, JSON.stringify(body))
+
+    await expect(client.execute(req, {})).resolves.toEqual(
+      new Response(200, body),
+    )
+  })
+
+  it('strips non-JSON body without error', async () => {
+    const req = new PushRequest()
+
+    const body = '<html>foo</html>'
+    mockResponseOnce(200, body)
+
+    await expect(client.execute(req, {})).resolves.toEqual(
+      new Response(200, undefined),
+    )
+  })
+})
+
+describe('when receiving error response', () => {
+  it('parses JSON body without error', async () => {
+    const req = new PushRequest()
+
+    const body = { foo: 'bar' }
+    mockResponseOnce(400, JSON.stringify(body))
+
+    await expect(client.execute(req, {})).rejects.toEqual(
+      new Response(400, body),
+    )
+  })
+
+  it('strips non-JSON body without error', async () => {
+    const req = new PushRequest()
+
+    const body = '<html>foo</html>'
+    mockResponseOnce(400, body)
+
+    await expect(client.execute(req, {})).rejects.toEqual(
+      new Response(400, undefined),
+    )
+  })
+
+  it('retrieves statusCode without error', async () => {
+    const req = new PushRequest()
+
+    const body = { foo: 'bar' }
+    mockResponseOnce(400, JSON.stringify(body))
+
+    await expect(client.execute(req, {})).rejects.toMatchObject(
+      new Response(400, body),
+    )
+  })
+})
+
+describe('when erroring before making request', () => {
+  it('does not error retrieving statusCode', async () => {
+    const req = new PushRequest()
+
+    // This will error if not mocked as the baseUrl provided to the client in
+    // `beforeEach` is an empty string.
+    await expect(client.execute(req, {})).rejects.toThrow(
+      'Invalid URI "/api/push/"',
+    )
+  })
+})
+
+const mockResponseOnce = (statusCode: number, body: string) => {
+  postSpy.mockImplementationOnce((_, callback) => {
+    callback!(null, { statusCode } as request.Response, body)
+    return {} as request.Request
+  })
+}


### PR DESCRIPTION
Two errors were mentioned in the original ticket. 

- ` Cannot read property 'statusCode' of undefined`. This is caused on line 33 by trying to read `statusCode` from a `res` which might be undefined (it will be in the case that `err` is truthy), since that's an error thrown locally before a request is made, and so there will be no response. The fix here is applied on line 33.

- `Unexpected token < in JSON at position 1 at JSON.parse`. This one is more apparent; the body in some cases us html and thus not JSON parsable. I applied a function to try to parse and to just replace with `undefined` if the parse fails. I don't love this solution and I'm very open to others. I assume error only happens in the case of non-200 status responses, but I applied the change for the success branch (the last if-else chain item) also just in case.